### PR TITLE
Analyze CodeQL scanned files

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,10 +45,19 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         queries: security-and-quality
-
-    - name: Build
+        debug: true
+          
+    # Build and analyze each scheme separately
+    - name: Build and analyze CheckoutCardManagement
       run: |
-        xcodebuild -scheme CheckoutCardManagement -destination "platform=iOS Simulator,name=iPhone 14 Pro,OS=latest"
+          xcodebuild -scheme CheckoutCardManagement -destination "platform=iOS Simulator,name=iPhone 14 Pro,OS=latest"
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+    - name: Build and analyze CheckoutCardManagementStub
+      run: |
+          xcodebuild -scheme CheckoutCardManagementStub -destination "platform=iOS Simulator,name=iPhone 14 Pro,OS=latest"
+
+    # Perform analysis on the code
+    - name: Analyze code with CodeQL
+      uses: github/codeql-action/analyze@v2
+      with:
+          database: ${{ github.workspace }}


### PR DESCRIPTION
Initially, CodeQL was scanning 21/74 files because it was just taking CheckoutCardManagement into account. 
Added CheckoutCardManagementStub also as part of CodeQL scan. 
Now 41/74 files are being scanned. Rest of the files belong to Sample Application

[PIMOB-2428](https://checkout.atlassian.net/browse/PIMOB-2428)

[PIMOB-2428]: https://checkout.atlassian.net/browse/PIMOB-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ